### PR TITLE
Modify pluggable components to use merged config value to do configuration.

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerDiskUsageDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/kafkaassigner/KafkaAssignerDiskUsageDistributionGoal.java
@@ -71,13 +71,9 @@ public class KafkaAssignerDiskUsageDistributionGoal implements Goal {
 
   @Override
   public void configure(Map<String, ?> configs) {
-    _balancingConstraint = new BalancingConstraint(new KafkaCruiseControlConfig(configs, false));
-    String minMonitoredPartitionPercentageString =
-        (String) configs.get(KafkaCruiseControlConfig.MIN_VALID_PARTITION_RATIO_CONFIG);
-    if (minMonitoredPartitionPercentageString != null
-        && !minMonitoredPartitionPercentageString.isEmpty()) {
-      _minMonitoredPartitionPercentage = Double.parseDouble(minMonitoredPartitionPercentageString);
-    }
+    KafkaCruiseControlConfig parsedConfig = new KafkaCruiseControlConfig(configs, false);
+    _balancingConstraint = new BalancingConstraint(parsedConfig);
+    _minMonitoredPartitionPercentage = parsedConfig.getDouble(KafkaCruiseControlConfig.MIN_VALID_PARTITION_RATIO_CONFIG);
   }
 
   @Override

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
@@ -1380,11 +1380,21 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
         .withClientSaslSupport();
   }
 
+  private Map<String, Object> mergedConfigValues() {
+    Map<String, Object> conf = originals();
+
+    // use parsed value to overwrite originals
+    // this will keep default values and also keep values that are not defined under ConfigDef
+    conf.putAll(values());
+
+    return conf;
+  }
+
   @Override
   public <T> T getConfiguredInstance(String key, Class<T> t) {
     T o = super.getConfiguredInstance(key, t);
     if (o instanceof CruiseControlConfigurable) {
-      ((CruiseControlConfigurable) o).configure(values());
+      ((CruiseControlConfigurable) o).configure(mergedConfigValues());
     }
     return o;
   }
@@ -1394,17 +1404,16 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
     List<T> objects = super.getConfiguredInstances(key, t);
     for (T o : objects) {
       if (o instanceof CruiseControlConfigurable) {
-        ((CruiseControlConfigurable) o).configure(values());
+        ((CruiseControlConfigurable) o).configure(mergedConfigValues());
       }
     }
     return objects;
   }
 
-  @SuppressWarnings("unchecked")
   @Override
   public <T> List<T> getConfiguredInstances(String key, Class<T> t, Map<String, Object> configOverrides) {
     List<T> objects = super.getConfiguredInstances(key, t, configOverrides);
-    Map<String, Object> configPairs = (Map<String, Object>) values();
+    Map<String, Object> configPairs = mergedConfigValues();
     configPairs.putAll(configOverrides);
     for (T o : objects) {
       if (o instanceof CruiseControlConfigurable) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
@@ -1380,13 +1380,16 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
         .withClientSaslSupport();
   }
 
-  private Map<String, Object> mergedConfigValues() {
+  public Map<String, Object> mergedConfigValues() {
     Map<String, Object> conf = originals();
 
-    // use parsed value to overwrite originals
-    // this will keep default values and also keep values that are not defined under ConfigDef
-    conf.putAll(values());
-
+    // Use parsed non-null value to overwrite originals.
+    // This will keep default values and also keep values that are not defined under ConfigDef.
+    values().forEach((k, v) -> {
+      if (v != null) {
+        conf.put(k, v);
+      }
+    });
     return conf;
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
@@ -1384,7 +1384,7 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
   public <T> T getConfiguredInstance(String key, Class<T> t) {
     T o = super.getConfiguredInstance(key, t);
     if (o instanceof CruiseControlConfigurable) {
-      ((CruiseControlConfigurable) o).configure(originals());
+      ((CruiseControlConfigurable) o).configure(values());
     }
     return o;
   }
@@ -1394,16 +1394,17 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
     List<T> objects = super.getConfiguredInstances(key, t);
     for (T o : objects) {
       if (o instanceof CruiseControlConfigurable) {
-        ((CruiseControlConfigurable) o).configure(originals());
+        ((CruiseControlConfigurable) o).configure(values());
       }
     }
     return objects;
   }
 
+  @SuppressWarnings("unchecked")
   @Override
   public <T> List<T> getConfiguredInstances(String key, Class<T> t, Map<String, Object> configOverrides) {
     List<T> objects = super.getConfiguredInstances(key, t, configOverrides);
-    Map<String, Object> configPairs = originals();
+    Map<String, Object> configPairs = (Map<String, Object>) values();
     configPairs.putAll(configOverrides);
     for (T o : objects) {
       if (o instanceof CruiseControlConfigurable) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/CruiseControlMetricsReporterSampler.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/CruiseControlMetricsReporterSampler.java
@@ -205,15 +205,19 @@ public class CruiseControlMetricsReporterSampler implements MetricSampler {
 
   @Override
   public void configure(Map<String, ?> configs) {
-    String numSamplersString = (String) configs.get(KafkaCruiseControlConfig.NUM_METRIC_FETCHERS_CONFIG);
-    if (numSamplersString != null && Integer.parseInt(numSamplersString) != 1) {
+    int numSamplers = (Integer) configs.get(KafkaCruiseControlConfig.NUM_METRIC_FETCHERS_CONFIG);
+    if (numSamplers != 1) {
       throw new ConfigException("CruiseControlMetricsReporterSampler is not thread safe. Please change " +
                                     KafkaCruiseControlConfig.NUM_METRIC_FETCHERS_CONFIG + " to 1");
     }
 
     String bootstrapServers = (String) configs.get(METRIC_REPORTER_SAMPLER_BOOTSTRAP_SERVERS);
     if (bootstrapServers == null) {
-      bootstrapServers = (String) configs.get(KafkaCruiseControlConfig.BOOTSTRAP_SERVERS_CONFIG);
+      bootstrapServers = configs.get(KafkaCruiseControlConfig.BOOTSTRAP_SERVERS_CONFIG).toString();
+      // Trim the brackets in List's String representation.
+      if (bootstrapServers.length() > 2) {
+        bootstrapServers = bootstrapServers.substring(1, bootstrapServers.length() - 1);
+      }
     }
     _metricReporterTopic = (String) configs.get(METRIC_REPORTER_TOPIC);
     if (_metricReporterTopic == null) {
@@ -226,10 +230,7 @@ public class CruiseControlMetricsReporterSampler implements MetricSampler {
     if (groupId == null) {
       groupId = DEFAULT_METRIC_REPORTER_SAMPLER_GROUP_ID + "-" + RANDOM.nextLong();
     }
-    String reconnectBackoffMs = (String) configs.get(KafkaCruiseControlConfig.RECONNECT_BACKOFF_MS_CONFIG);
-    if (reconnectBackoffMs == null) {
-      reconnectBackoffMs = String.valueOf(DEFAULT_RECONNECT_BACKOFF_MS);
-    }
+    String reconnectBackoffMs = configs.get(KafkaCruiseControlConfig.RECONNECT_BACKOFF_MS_CONFIG).toString();
 
     CruiseControlMetricsReporterConfig reporterConfig = new CruiseControlMetricsReporterConfig(configs, false);
     _acceptableMetricRecordProduceDelayMs = ACCEPTABLE_NETWORK_DELAY_MS +

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/KafkaSampleStore.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/KafkaSampleStore.java
@@ -91,7 +91,6 @@ public class KafkaSampleStore implements SampleStore {
   protected static final int DEFAULT_BROKER_SAMPLE_STORE_TOPIC_PARTITION_COUNT = 32;
   protected static final long DEFAULT_MIN_PARTITION_SAMPLE_STORE_TOPIC_RETENTION_TIME_MS = 3600000L;
   protected static final long DEFAULT_MIN_BROKER_SAMPLE_STORE_TOPIC_RETENTION_TIME_MS = 3600000L;
-  protected static final long DEFAULT_RECONNECT_BACKOFF_MS = 50L;
   protected static final String PRODUCER_CLIENT_ID = "KafkaCruiseControlSampleStoreProducer";
   protected static final String CONSUMER_CLIENT_ID = "KafkaCruiseControlSampleStoreConsumer";
   protected static final Random RANDOM = new Random();
@@ -166,8 +165,12 @@ public class KafkaSampleStore implements SampleStore {
   protected KafkaProducer<byte[], byte[]> createProducer(Map<String, ?> config) {
     Properties producerProps = new Properties();
     producerProps.putAll(config);
-    producerProps.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
-                              (String) config.get(KafkaCruiseControlConfig.BOOTSTRAP_SERVERS_CONFIG));
+    String bootstrapServers = config.get(KafkaCruiseControlConfig.BOOTSTRAP_SERVERS_CONFIG).toString();
+    // Trim the brackets in List's String representation.
+    if (bootstrapServers.length() > 2) {
+      bootstrapServers = bootstrapServers.substring(1, bootstrapServers.length() - 1);
+    }
+    producerProps.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     producerProps.setProperty(ProducerConfig.CLIENT_ID_CONFIG, PRODUCER_CLIENT_ID);
     // Set batch.size and linger.ms to a big number to have better batching.
     producerProps.setProperty(ProducerConfig.LINGER_MS_CONFIG, "30000");
@@ -178,7 +181,7 @@ public class KafkaSampleStore implements SampleStore {
     producerProps.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
     producerProps.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
     producerProps.setProperty(ProducerConfig.RECONNECT_BACKOFF_MS_CONFIG,
-                              (String) config.get(KafkaCruiseControlConfig.RECONNECT_BACKOFF_MS_CONFIG));
+                              config.get(KafkaCruiseControlConfig.RECONNECT_BACKOFF_MS_CONFIG).toString());
     return new KafkaProducer<>(producerProps);
   }
 
@@ -186,12 +189,12 @@ public class KafkaSampleStore implements SampleStore {
     Properties consumerProps = new Properties();
     consumerProps.putAll(config);
     long randomToken = RANDOM.nextLong();
-    String reconnectBackoffMs = (String) config.get(KafkaCruiseControlConfig.RECONNECT_BACKOFF_MS_CONFIG);
-    if (reconnectBackoffMs == null) {
-      reconnectBackoffMs = String.valueOf(DEFAULT_RECONNECT_BACKOFF_MS);
+    String bootstrapServers = config.get(KafkaCruiseControlConfig.BOOTSTRAP_SERVERS_CONFIG).toString();
+    // Trim the brackets in List's String representation.
+    if (bootstrapServers.length() > 2) {
+      bootstrapServers = bootstrapServers.substring(1, bootstrapServers.length() - 1);
     }
-    consumerProps.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
-                              (String) config.get(KafkaCruiseControlConfig.BOOTSTRAP_SERVERS_CONFIG));
+    consumerProps.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     consumerProps.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "KafkaCruiseControlSampleStore" + randomToken);
     consumerProps.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, CONSUMER_CLIENT_ID + randomToken);
     consumerProps.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
@@ -199,7 +202,8 @@ public class KafkaSampleStore implements SampleStore {
     consumerProps.setProperty(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, Integer.toString(Integer.MAX_VALUE));
     consumerProps.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
     consumerProps.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
-    consumerProps.setProperty(ConsumerConfig.RECONNECT_BACKOFF_MS_CONFIG, reconnectBackoffMs);
+    consumerProps.setProperty(ConsumerConfig.RECONNECT_BACKOFF_MS_CONFIG,
+                                             config.get(KafkaCruiseControlConfig.RECONNECT_BACKOFF_MS_CONFIG).toString());
     return new KafkaConsumer<>(consumerProps);
   }
 
@@ -208,16 +212,14 @@ public class KafkaSampleStore implements SampleStore {
     ZkUtils zkUtils = KafkaCruiseControlUtils.createZkUtils(zkConnect);
     try {
       Map<String, List<PartitionInfo>> topics = _consumers.get(0).listTopics();
-      long partitionSampleWindowMs = Long.parseLong((String) config.get(KafkaCruiseControlConfig.PARTITION_METRICS_WINDOW_MS_CONFIG));
-      long brokerSampleWindowMs = Long.parseLong((String) config.get(KafkaCruiseControlConfig.BROKER_METRICS_WINDOW_MS_CONFIG));
+      long partitionSampleWindowMs = (Long) config.get(KafkaCruiseControlConfig.PARTITION_METRICS_WINDOW_MS_CONFIG);
+      long brokerSampleWindowMs = (Long) config.get(KafkaCruiseControlConfig.BROKER_METRICS_WINDOW_MS_CONFIG);
 
-      int numPartitionSampleWindows =
-          Integer.parseInt((String) config.get(KafkaCruiseControlConfig.NUM_PARTITION_METRICS_WINDOWS_CONFIG));
+      int numPartitionSampleWindows = (Integer) config.get(KafkaCruiseControlConfig.NUM_PARTITION_METRICS_WINDOWS_CONFIG);
       long partitionSampleRetentionMs = (numPartitionSampleWindows * ADDITIONAL_WINDOW_TO_RETAIN_FACTOR) * partitionSampleWindowMs;
       partitionSampleRetentionMs = Math.max(_minPartitionSampleStoreTopicRetentionTimeMs, partitionSampleRetentionMs);
 
-      int numBrokerSampleWindows =
-          Integer.parseInt((String) config.get(KafkaCruiseControlConfig.NUM_BROKER_METRICS_WINDOWS_CONFIG));
+      int numBrokerSampleWindows = (Integer) config.get(KafkaCruiseControlConfig.NUM_BROKER_METRICS_WINDOWS_CONFIG);
       long brokerSampleRetentionMs = (numBrokerSampleWindows * ADDITIONAL_WINDOW_TO_RETAIN_FACTOR) * brokerSampleWindowMs;
       brokerSampleRetentionMs = Math.max(_minBrokerSampleStoreTopicRetentionTimeMs, brokerSampleRetentionMs);
 
@@ -225,8 +227,7 @@ public class KafkaSampleStore implements SampleStore {
       if (numberOfBrokersInCluster <= 1) {
         throw new IllegalStateException(
             String.format("Kafka cluster has less than 2 brokers (brokers in cluster=%d, zookeeper.connect=%s)",
-                          numberOfBrokersInCluster, config.get(KafkaCruiseControlConfig.ZOOKEEPER_CONNECT_CONFIG)));
-
+                          numberOfBrokersInCluster, zkConnect));
       }
       int replicationFactor = _sampleStoreTopicReplicationFactor == null ? Math.min(DEFAULT_SAMPLE_STORE_TOPIC_REPLICATION_FACTOR,
                               numberOfBrokersInCluster) : _sampleStoreTopicReplicationFactor;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/MetricFetcherManager.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/MetricFetcherManager.java
@@ -127,13 +127,13 @@ public class MetricFetcherManager {
       for (int i = 0; i < _numMetricFetchers; i++) {
         MetricSampler metricSampler =
             config.getConfiguredInstance(KafkaCruiseControlConfig.METRIC_SAMPLER_CLASS_CONFIG, MetricSampler.class);
-        metricSampler.configure(config.originals());
+        metricSampler.configure(config.mergedConfigValues());
         _metricSamplers.add(metricSampler);
       }
     }
     _partitionAssignor = config.getConfiguredInstance(KafkaCruiseControlConfig.METRIC_SAMPLER_PARTITION_ASSIGNOR_CLASS_CONFIG,
                                                       MetricSamplerPartitionAssignor.class);
-    _partitionAssignor.configure(config.originals());
+    _partitionAssignor.configure(config.mergedConfigValues());
     _useLinearRegressionModel = config.getBoolean(KafkaCruiseControlConfig.USE_LINEAR_REGRESSION_MODEL_CONFIG);
     _dropwizardMetricRegistry = dropwizardMetricRegistry;
     _samplingFetcherTimer = _dropwizardMetricRegistry.timer(MetricRegistry.name("MetricFetcherManager",


### PR DESCRIPTION
To make pluggable components properly pick up the merged config(instead of original config), we need to make some change to their  `configure(Map<String, ?> configs)` method so that they will honor the defined type in `KafkaCruiseControlConfig`.